### PR TITLE
Implement escapes using Display trait

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use crate::escape::escape_str_attribute;
+use crate::escape::{Escaped, AttributeEscapes};
 use crate::name::{Name, OwnedName};
 
 /// A borrowed version of an XML attribute.
@@ -20,7 +20,7 @@ pub struct Attribute<'a> {
 
 impl<'a> fmt::Display for Attribute<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}=\"{}\"", self.name, escape_str_attribute(self.value))
+        write!(f, "{}=\"{}\"", self.name, Escaped::<AttributeEscapes>::new(self.value))
     }
 }
 
@@ -78,7 +78,7 @@ impl OwnedAttribute {
 
 impl fmt::Display for OwnedAttribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}=\"{}\"", self.name, escape_str_attribute(&self.value))
+        write!(f, "{}=\"{}\"", self.name, Escaped::<AttributeEscapes>::new(&self.value))
     }
 }
 


### PR DESCRIPTION
This is a reimplementation for the `escape` module which can directly write to an output using the `Display` trait and thereby avoids additional String allocation.

@kornelski first suggested to use `io::Write` or `fmt::Write`, but since escaped characters are actually something that is being written rather something to write to, implementing `Display` made more sense in my opinion.
`Displays` allows us to write to `io::Write` as well as `fmt::Write` (used in `attribute.rs`) which is not possible the other way around (by implementing `io::Write` or `fmt::Write`).

The existing `escape_str_attribute` and `escape_str_pcdata` functions are still around, but not used anywhere internally anymore. But since they are part of the public API I think they have to stay.
These might have a slight performance regression, because the string is now iterated twice (once for checking if escaping and thus allocation is necessary and again for the actual escaping).