### PR TITLE
fixup/writer: minor change for encoding case

### DIFF
--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -224,7 +224,7 @@ impl Emitter {
 
     fn check_document_started<W: Write>(&mut self, target: &mut W) -> Result<()> {
         if !self.start_document_emitted && self.config.write_document_declaration {
-            self.emit_start_document(target, common::XmlVersion::Version10, "utf-8", None)
+            self.emit_start_document(target, common::XmlVersion::Version10, "UTF-8", None)
         } else {
             Ok(())
         }


### PR DESCRIPTION
Change the explicit encoding used in `writer::Emitter` to be `UTF-8` for consistency with the rest of the library.