### PR TITLE
Replace disallowed characters

### DIFF
--- a/src/reader/parser/inside_reference.rs
+++ b/src/reader/parser/inside_reference.rs
@@ -68,6 +68,7 @@ impl PullParser {
         };
         match char::from_u32(val) {
             Some(c) if self.is_valid_xml_char(c) => Ok(c),
+            Some(_) if self.config.c.replace_unknown_entity_references => Ok('\u{fffd}'),
             None if self.config.c.replace_unknown_entity_references => {
                 Ok('\u{fffd}')
             },


### PR DESCRIPTION
Make it possible for the parser to successfully parse anny XML document that contains characters that are invalid according to the XML spec.

A document that contains a character entity reference that resolves to an invalid character according to the XML spec – for example `<doc>&#x10;</doc>` – is *technically* invalid according to the XML specification. However, replacing these with U+FFFD is both better for the consuming application (because the application does not need to do some weird pre-processing of the document before parsing it). This takes previous work that already handled this for surrogate pairs and extends it to any invalid unicode character.

This, similar to the previous work, technically makes the XML parser non-conformant, so put it behind the existing
`replace_unknown_entity_references` field on ParserConfig.

---

Previous context at:
* https://github.com/netvl/xml-rs/issues/187
* https://github.com/netvl/xml-rs/pull/189