### PR TITLE
EventWriter: escape '>' in characters

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -93,6 +93,7 @@ escapes!(
 escapes!(
     PcDataEscapes,
     b'<' => "&lt;",
+    b'>' => "&gt;",
     b'&' => "&amp;",
 );
 
@@ -150,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_escape_str_pcdata() {
-        assert_eq!(escape_str_pcdata("<&"), "&lt;&amp;");
+        assert_eq!(escape_str_pcdata("<>&"), "&lt;&gt;&amp;");
         assert_eq!(escape_str_pcdata("no_escapes"), "no_escapes");
     }
 


### PR DESCRIPTION
Fixes an issue where the emitter would produce XML which cannot be parsed back (the reader panics):
- Writer emits the characters `]]>`.
- Reader interprets this as a CDATA suffix instead of the literal `]]>`, and panics.

This issue can occur in particular when processing dumps of MediaWiki markup which uses `[[...]]` to denote links: `Let [[x]]>0`.

A simple fix is to escape all `>` characters in text when emitting XML. This avoids accidentally forming `]]>` substrings in the XML.