### PR TITLE
Add `EventWriter::inner_ref`

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -79,6 +79,11 @@ impl<W: Write> EventWriter<W> {
         &mut self.sink
     }
 
+    /// Returns an immutable reference to the underlying `Writer`.
+    pub fn inner_ref(&self) -> &W {
+        &self.sink
+    }
+
     /// Unwraps this `EventWriter`, returning the underlying writer.
     ///
     /// Note that this is a destructive operation: unwrapping a writer and then wrapping


### PR DESCRIPTION
Hi,
I hope you are open to PRs.

This is a very simple one that just allows you to get an immutable reference to the underlying writer of an `EventWriter` using `EventWriter::inner_ref`.
