### PR TITLE
WIP: Permit no spaces between attributes

### DIFF
--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -794,6 +794,16 @@ mod tests {
     }
 
     #[test]
+    fn attributes_without_spaces_inbetween() {
+        let (mut r, mut p) = test_data!(r#"
+            <a attr="xxx"attr2="zzz" />
+        "#);
+
+        expect_event!(r, p, Ok(XmlEvent::StartDocument { .. }));
+        expect_event!(r, p, Ok(XmlEvent::StartElement { .. }));
+    }
+
+    #[test]
     fn reference_err() {
         let (mut r, mut p) = test_data!(r"
             <a>&&amp;</a>

--- a/src/reader/parser/inside_opening_tag.rs
+++ b/src/reader/parser/inside_opening_tag.rs
@@ -113,7 +113,14 @@ impl PullParser {
                 },
                 Token::TagEnd => self.emit_start_element(false),
                 Token::EmptyTagEnd => self.emit_start_element(true),
-                _ => Some(self.error(SyntaxError::UnexpectedTokenInOpeningTag(t))),
+                Token::Character(c) if is_name_start_char(c) => {
+                    if self.buf.len() > self.config.max_name_length {
+                        return Some(self.error(SyntaxError::ExceededConfiguredLimit));
+                    }
+                    self.buf.push(c);
+                    self.into_state_continue(State::InsideOpeningTag(OpeningTagSubstate::InsideAttributeName))
+                },
+                _ => Some(self.error(SyntaxError::UnexpectedTokenInOpeningTag(t))) ,
             },
         }
     }


### PR DESCRIPTION
The XML parser currently emits an error when it encounters attributes which are not separated by whitespace.

I am working on an application that uses xml-rs via the xmltree crate to parse HTML which is not always formatted very neatly. One such document has attributes formatted like this, which aborts parsing of the whole document.

The solution I propose here makes the parser just start reading a new attribute. The test suite does not pass yet, but it does serve as an example.

Please let me know what you think :)