### PR TITLE
Convert `xml::reader::XmlEvent` to `xml::writer::XmlEvent`

### DIFF
--- a/src/writer/events.rs
+++ b/src/writer/events.rs
@@ -257,42 +257,12 @@ impl<'a> From<StartElementBuilder<'a>> for XmlEvent<'a> {
 }
 
 impl<'a> TryFrom<&'a crate::reader::XmlEvent> for XmlEvent<'a> {
-    type Error = ();
+    type Error = crate::reader::Error;
 
     fn try_from(event: &crate::reader::XmlEvent) -> Result<XmlEvent<'_>, Self::Error> {
-            match event {
-                crate::reader::XmlEvent::StartDocument {
-                    version,
-                    encoding,
-                    standalone,
-                } => Ok(XmlEvent::StartDocument {
-                    version: version.clone(),
-                    encoding: Some(&encoding),
-                    standalone: standalone.clone(),
-                }),
-                crate::reader::XmlEvent::EndDocument => Err(()),
-                crate::reader::XmlEvent::ProcessingInstruction { name, data } => {
-                    Ok(XmlEvent::ProcessingInstruction {
-                        name: &name,
-                        data: data.as_deref(),
-                    })
-                }
-                crate::reader::XmlEvent::StartElement {
-                    name,
-                    attributes,
-                    namespace,
-                } => Ok(XmlEvent::StartElement {
-                    name: name.borrow(),
-                    attributes: Cow::Owned(attributes.iter().map(|attr| attr.borrow()).collect()),
-                    namespace: namespace.borrow(),
-                }),
-                crate::reader::XmlEvent::EndElement { name } => Ok(XmlEvent::EndElement {
-                    name: Some(name.borrow()),
-                }),
-                crate::reader::XmlEvent::CData(chars) => Ok(XmlEvent::CData(chars)),
-                crate::reader::XmlEvent::Comment(chars) => Ok(XmlEvent::Comment(chars)),
-                crate::reader::XmlEvent::Characters(chars) => Ok(XmlEvent::Characters(chars)),
-                crate::reader::XmlEvent::Whitespace(chars) => Ok(XmlEvent::Characters(chars)),
-            }
+        event.as_writer_event().ok_or(crate::reader::Error {
+            pos: crate::common::TextPosition::new(),
+            kind: crate::reader::ErrorKind::UnexpectedEof,
+        })
     }
 }


### PR DESCRIPTION
In the XML document I'm processing, there are "sub documents" that I'd like to collect and store as strings. The straightforward way to do this seems to be to convert the reader `XmlEvent`s into writer `XmlEvent`s.

I wrote a `TryFrom` instance to do as much. (In my own code, it's just a function.)

A more efficient way to manage this would be to keep track of the underlying span in the source and then just grab the raw bytes of the source, but it's not clear to me how easy to me that would be.