### PR TITLE
Also flag "<?" as error inside attribute values

### DIFF
--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -792,7 +792,7 @@ mod tests {
             }
         );
     }
- 
+
     #[test]
     fn processing_instruction_in_attribute_value() {
         use crate::reader::error::{SyntaxError, Error, ErrorKind};


### PR DESCRIPTION
`read_attribute_value` returns a `SyntaxError` when it detects `OpeningTagStart`, because it means "<" in an attribute value, which is invalid XML. However, another token, `ProcessingInstructionStart` also starts with "<" and so its presence in an attribute value also indicates invalid XML for the same reasons. So far, the other token was not caught by `read_attribute_value`, resulting in erroneously accepting, e.g., "<y F="<?abc"><x G="/">".

This change makes `read_attribute_value` return the same error on `ProcessingInstructionStart` as it has been returning on `OpeningTagStart`.

Pair-debugged with @1c3t3a. Fixes https://github.com/kornelski/xml-rs/issues/38.