### PR TITLE
Writer: Add RawCharacters for emitting non-escaped characters

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -66,6 +66,7 @@ impl<W: Write> EventWriter<W> {
             XmlEvent::Comment(content) => self.emitter.emit_comment(&mut self.sink, content),
             XmlEvent::CData(content) => self.emitter.emit_cdata(&mut self.sink, content),
             XmlEvent::Characters(content) => self.emitter.emit_characters(&mut self.sink, content),
+            XmlEvent::RawCharacters(content) => self.emitter.emit_raw_characters(&mut self.sink, content),
         }
     }
 

--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -405,6 +405,16 @@ impl Emitter {
         Ok(())
     }
 
+    pub fn emit_raw_characters<W: Write>(&mut self, target: &mut W, content: &str) -> Result<()> {
+        self.check_document_started(target)?;
+        self.fix_non_empty_element(target)?;
+
+        target.write_all(content.as_bytes())?;
+
+        self.after_text();
+        Ok(())
+    }
+
     pub fn emit_comment<W: Write>(&mut self, target: &mut W, content: &str) -> Result<()> {
         self.fix_non_empty_element(target)?;
 

--- a/src/writer/events.rs
+++ b/src/writer/events.rs
@@ -91,6 +91,13 @@ pub enum XmlEvent<'a> {
     /// Contents of this event will be escaped if `perform_escaping` option is enabled,
     /// that is, every character invalid for PCDATA will appear as a character entity.
     Characters(&'a str),
+
+    /// Emits raw characters which will never be escaped.
+    ///
+    /// This event is only used for writing to an output stream, there is no equivalent
+    /// reader event. Care must be taken when using this event, as it can easily result
+    /// non-well-formed documents.
+    RawCharacters(&'a str),
 }
 
 impl<'a> XmlEvent<'a> {
@@ -142,6 +149,18 @@ impl<'a> XmlEvent<'a> {
     #[must_use]
     pub const fn characters(data: &'a str) -> Self {
         XmlEvent::Characters(data)
+    }
+
+    /// Returns a raw characters event.
+    ///
+    /// No escaping takes place.
+    /// This event is only used for writing to an output stream, there is no equivalent
+    /// reader event. Care must be taken when using this event, as it can easily result
+    /// non-well-formed documents.
+    #[inline]
+    #[must_use]
+    pub const fn raw_characters(data: &'a str) -> Self {
+        XmlEvent::RawCharacters(data)
     }
 
     /// Returns a comment event.


### PR DESCRIPTION
Sometimes it can be useful to emit unescaped characters, as it can be difficult to change the global EmitterConfig option `perform_escaping` on the fly to non-escape only some characters of the document.