### PR TITLE
fix attributes namespace.

### DIFF
--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -665,7 +665,7 @@ fn issue_attribues_have_no_default_namespace() {
         br#"<hello xmlns="urn:foo" x="y"/>"#,
         br#"
             |StartDocument(1.0, UTF-8)
-            |StartElement({urn:foo}hello [x="y"])
+            |StartElement({urn:foo}hello [{urn:foo}x="y"])
             |EndElement({urn:foo}hello)
             |EndDocument
         "#,


### PR DESCRIPTION
If an element has a new default namespace, that namespace should be passed onto the attributes if they don't have a specific namespace.

This fixes #42 and https://github.com/AS207960/xml-serde/issues/15.

Without this, this code:

```rust
    let input = r#"<?xml version="1.0" encoding="UTF-8"?>
<stuff xmlns="domain" a="123">foobar</stuff>"#;

    let conf = ::xml::ParserConfig::new()
        .trim_whitespace(true)
        .whitespace_to_characters(true)
        .replace_unknown_entity_references(true);
    let mut event_reader = ::xml::reader::EventReader::new_with_config(input.as_bytes(), conf);

    while let Ok(e) = event_reader.next() {
        match e {
            XmlEvent::EndDocument => {
                println!("{e:?}");
                break;
            }
            e => println!("{e:?}"),
        }
    }
```

will output:

```rust
StartDocument(1.0, UTF-8, None)
StartElement({domain}stuff, {"": "domain", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [a -> 123])
Characters(foobar)
EndElement({domain}stuff)
```

With this fix, it will output:

```rust
StartDocument(1.0, UTF-8, None)
StartElement({domain}stuff, {"": "domain", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [{domain}a -> 123])
Characters(foobar)
EndElement({domain}stuff)
EndDocument
```

Added a test for it.