### PR TITLE
Provide name, public and system id in Doctype event

### DIFF
--- a/examples/print_events.rs
+++ b/examples/print_events.rs
@@ -51,7 +51,7 @@ fn main() {
                     XmlEvent::Whitespace(data) => {
                         println!(r#"Whitespace("{}")"#, data.escape_debug());
                     },
-                    XmlEvent::Doctype { syntax } => {
+                    XmlEvent::Doctype { syntax, .. } => {
                         println!(r#"Doctype("{}")"#, syntax.escape_debug());
                     },
                 }

--- a/examples/xml-analyze.rs
+++ b/examples/xml-analyze.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     if standalone.unwrap_or(false) { "" } else { "not " }
                 );
             },
-            XmlEvent::Doctype { syntax } => {
+            XmlEvent::Doctype { syntax , ..} => {
                 println!("The Doctype is: {syntax}");
             },
             XmlEvent::EndDocument => println!("Document finished"),

--- a/src/common.rs
+++ b/src/common.rs
@@ -129,6 +129,13 @@ pub const fn is_whitespace_char(c: char) -> bool {
     matches!(c, '\x20' | '\x0a' | '\x09' | '\x0d')
 }
 
+/// Matches the PubIdChar production.
+pub (crate) fn is_pubid_char(c: char) -> bool {
+    matches!(c, '\x20' | '\x0D' | '\x0A' | 'a'..='z' | 'A'..='Z' | '0'..='9' |
+        '-' | '\'' | '(' | ')' | '+' | ',' | '.' | '/' | ':' | '=' | '?' | ';' |
+        '!' | '*' | '#' | '@' | '$' | '_' | '%')
+}
+
 /// Checks whether the given string is compound only by white space
 /// characters (`S`) using the previous `is_whitespace_char` to check
 /// all characters of this string

--- a/src/reader/events.rs
+++ b/src/reader/events.rs
@@ -114,6 +114,12 @@ pub enum XmlEvent {
     Doctype {
         /// Everything including `<` and `>`
         syntax: String,
+        /// Doctype name, following <?DOCTYPE ...
+        name: String,
+        /// Public id of Doctype, if available. See https://www.w3.org/TR/xml/#NT-ExternalID
+        public_id: Option<String>,
+        /// System id of Doctype, if available See https://www.w3.org/TR/xml/#NT-ExternalID
+        system_id: Option<String>,
     },
 }
 
@@ -149,8 +155,8 @@ impl fmt::Debug for XmlEvent {
                 write!(f, "Characters({data})"),
             Self::Whitespace(data) =>
                 write!(f, "Whitespace({data})"),
-            Self::Doctype { syntax } =>
-                write!(f, "Doctype({syntax})"),
+            Self::Doctype { syntax, name, public_id, system_id } =>
+                write!(f, "Doctype({syntax}, {name}, {:?}, {:?})", public_id, system_id)
         }
     }
 }
@@ -223,7 +229,7 @@ impl XmlEvent {
             Self::CData(data) => Some(crate::writer::events::XmlEvent::CData(data)),
             Self::Characters(data) |
             Self::Whitespace(data) => Some(crate::writer::events::XmlEvent::Characters(data)),
-            Self::Doctype { syntax } => Some(crate::writer::events::XmlEvent::Doctype(syntax)),
+            Self::Doctype { syntax, .. } => Some(crate::writer::events::XmlEvent::Doctype(syntax)),
             Self::EndDocument => None,
         }
     }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -124,6 +124,9 @@ impl PullParser {
             data: MarkupData {
                 name: String::new(),
                 doctype: None,
+                doctype_name: String::new(),
+                doctype_public_id: None,
+                doctype_system_id: None,
                 version: None,
                 encoding: None,
                 standalone: None,
@@ -214,7 +217,17 @@ pub(crate) enum State {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub(crate) enum DoctypeSubstate {
+    BeforeDoctypeName,
+    DoctypeName,
     Outside,
+    // PUBLIC ... SYSTEM... public and system literal parts.
+    ExternalIdKeyword,
+    BeforeSystemLiteral,
+    SystemLiteral,
+    BeforePubId,
+    PubId,
+    // Internal Subset related bits, parts inside [...].
+    InternalSubset,
     String,
     InsideName,
     BeforeEntityName,
@@ -229,6 +242,7 @@ pub(crate) enum DoctypeSubstate {
     /// name definition
     PEReferenceDefinitionStart,
     PEReferenceDefinition,
+    IgnorePI,
     SkipDeclaration,
     Comment,
 }
@@ -321,6 +335,9 @@ struct MarkupData {
     ref_data: String,  // used for reference content
 
     doctype: Option<String>, // keeps a copy of the original doctype
+    doctype_name: String,
+    doctype_public_id: Option<String>,
+    doctype_system_id: Option<String>,
     version: Option<XmlVersion>,  // used for XML declaration version
     encoding: Option<String>,  // used for XML declaration encoding
     standalone: Option<bool>,  // used for XML declaration standalone parameter

--- a/src/reader/parser/inside_doctype.rs
+++ b/src/reader/parser/inside_doctype.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use crate::common::{is_name_char, is_name_start_char, is_whitespace_char};
+use crate::common::{is_name_char, is_name_start_char, is_pubid_char, is_whitespace_char};
 use crate::reader::error::SyntaxError;
 use crate::reader::lexer::Token;
 use crate::reader::XmlEvent;
@@ -17,32 +17,184 @@ impl PullParser {
         }
 
         match substate {
+            DoctypeSubstate::BeforeDoctypeName => match t {
+                Token::Character(c) if is_whitespace_char(c) => None,
+                Token::Character(c) if is_name_start_char(c) => {
+                    self.data.doctype_name.clear();
+                    self.buf.push(c);
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::DoctypeName))
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::DoctypeName => match t {
+                Token::TagEnd => {
+                    self.data.doctype_name = self.take_buf();
+                    let event = XmlEvent::Doctype {
+                        syntax: self.data.doctype.clone().unwrap_or_default(),
+                        name: self.data.doctype_name.clone(),
+                        public_id: self.data.doctype_public_id.clone(),
+                        system_id: self.data.doctype_system_id.clone(),
+                    };
+                    self.into_state_emit(State::OutsideTag, Ok(event))
+                }
+                Token::Character(c) if is_whitespace_char(c) => {
+                    self.data.doctype_name = self.take_buf();
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
+                }
+                Token::Character(c) if is_name_char(c) => {
+                    self.buf.push(c);
+                    if self.buf.len() > self.config.max_name_length {
+                        return Some(self.error(SyntaxError::ExceededConfiguredLimit));
+                    }
+                    None
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::ExternalIdKeyword => match t {
+                Token::Character(c @ 'A'..='Z') => {
+                    self.buf.push(c);
+                    if self.buf == "SYSTEM" {
+                        self.buf.clear();
+                        return self.into_state_continue(State::InsideDoctype(
+                            DoctypeSubstate::BeforeSystemLiteral,
+                        ));
+                    }
+                    if self.buf == "PUBLIC" {
+                        self.buf.clear();
+                        return self.into_state_continue(State::InsideDoctype(
+                            DoctypeSubstate::BeforePubId,
+                        ));
+                    }
+                    if "PUBLIC".starts_with(&self.buf) || "SYSTEM".starts_with(&self.buf) {
+                        return None;
+                    }
+                    Some(self.error(SyntaxError::UnexpectedToken(t)))
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::BeforeSystemLiteral => match t {
+                Token::Character(c) if is_whitespace_char(c) => None,
+                Token::SingleQuote | Token::DoubleQuote => {
+                    self.data.quote = super::QuoteToken::from_token(t);
+                    self.buf.clear();
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::SystemLiteral))
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::SystemLiteral => match t {
+                Token::SingleQuote if self.data.quote != Some(QuoteToken::SingleQuoteToken) => {
+                    self.buf.push('\'');
+                    None
+                }
+                Token::DoubleQuote if self.data.quote != Some(QuoteToken::DoubleQuoteToken) => {
+                    self.buf.push('"');
+                    None
+                }
+                Token::SingleQuote | Token::DoubleQuote => {
+                    self.data.quote = None;
+                    self.data.doctype_system_id = Some(self.take_buf());
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
+                }
+                Token::Character(c) => {
+                    self.buf.push(c);
+                    None
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::BeforePubId => match t {
+                Token::Character(c) if is_whitespace_char(c) => None,
+                Token::SingleQuote | Token::DoubleQuote => {
+                    self.data.quote = super::QuoteToken::from_token(t);
+                    self.buf.clear();
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PubId))
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::PubId => match t {
+                Token::SingleQuote if self.data.quote != Some(QuoteToken::SingleQuoteToken) => {
+                    self.buf.push('\'');
+                    None
+                }
+                Token::DoubleQuote if self.data.quote != Some(QuoteToken::DoubleQuoteToken) => {
+                    self.buf.push('"');
+                    None
+                }
+                Token::SingleQuote | Token::DoubleQuote => {
+                    self.data.quote = None;
+                    self.data.doctype_public_id = Some(self.take_buf());
+                    self.into_state_continue(State::InsideDoctype(
+                        DoctypeSubstate::BeforeSystemLiteral,
+                    ))
+                }
+                Token::Character(c) if is_pubid_char(c) => {
+                    self.buf.push(c);
+                    None
+                }
+                Token::ReferenceEnd => {
+                    self.buf.push(';');
+                    None
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
             DoctypeSubstate::Outside => match t {
                 Token::TagEnd => {
                     let event = XmlEvent::Doctype {
                         syntax: self.data.doctype.clone().unwrap_or_default(),
+                        name: self.data.doctype_name.clone(),
+                        public_id: self.data.doctype_public_id.clone(),
+                        system_id: self.data.doctype_system_id.clone(),
                     };
                     self.into_state_emit(State::OutsideTag, Ok(event))
-                },
-                Token::MarkupDeclarationStart => {
-                    self.buf.clear();
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InsideName))
-                },
-                Token::Character('%') => {
-                    self.data.ref_data.clear();
-                    self.data.ref_data.push('%');
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PEReferenceInDtd))
-                },
-                Token::CommentStart => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Comment))
-                },
+                }
+                Token::CDataEnd | Token::CDataStart => {
+                    Some(self.error(SyntaxError::UnexpectedToken(t)))
+                }
+                Token::Character(c) if c == '[' => {
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset))
+                }
+                Token::Character(c) if c == 'S' || c == 'P' => {
+                    self.buf.push(c);
+                    self.into_state_continue(State::InsideDoctype(
+                        DoctypeSubstate::ExternalIdKeyword,
+                    ))
+                }
+                Token::Character(c) if is_whitespace_char(c) => None,
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::InternalSubset => match t {
+                Token::Character(c) if c == ']' => {
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
+                }
+
                 Token::SingleQuote | Token::DoubleQuote => {
                     // just discard string literals
                     self.data.quote = super::QuoteToken::from_token(t);
                     self.into_state_continue(State::InsideDoctype(DoctypeSubstate::String))
-                },
-                Token::CDataEnd | Token::CDataStart => Some(self.error(SyntaxError::UnexpectedToken(t))),
-                // TODO: parse SYSTEM, and [
+                }
+                Token::CommentStart => {
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Comment))
+                }
+                Token::Character('%') => {
+                    self.data.ref_data.clear();
+                    self.data.ref_data.push('%');
+                    self.into_state_continue(State::InsideDoctype(
+                        DoctypeSubstate::PEReferenceInDtd,
+                    ))
+                }
+                Token::MarkupDeclarationStart => {
+                    self.buf.clear();
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InsideName))
+                }
+                Token::Character(c) if is_whitespace_char(c) => None,
+                Token::ProcessingInstructionStart => {
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::IgnorePI))
+                }
+                _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
+            },
+            DoctypeSubstate::IgnorePI => match t {
+                Token::ProcessingInstructionEnd => {
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset))
+                }
                 _ => None,
             },
             DoctypeSubstate::String => match t {
@@ -50,62 +202,66 @@ impl PullParser {
                 Token::DoubleQuote if self.data.quote != Some(QuoteToken::DoubleQuoteToken) => None,
                 Token::SingleQuote | Token::DoubleQuote => {
                     self.data.quote = None;
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
-                },
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset))
+                }
                 _ => None,
             },
             DoctypeSubstate::Comment => match t {
                 Token::CommentEnd => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
-                },
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset))
+                }
                 _ => None,
             },
             DoctypeSubstate::InsideName => match t {
                 Token::Character(c @ 'A'..='Z') => {
                     self.buf.push(c);
                     None
-                },
+                }
                 Token::Character(c) if is_whitespace_char(c) => {
                     let buf = self.take_buf();
                     match buf.as_str() {
-                        "ENTITY" => self.into_state_continue(State::InsideDoctype(DoctypeSubstate::BeforeEntityName)),
-                        "NOTATION" | "ELEMENT" | "ATTLIST" => {
-                            self.into_state_continue(State::InsideDoctype(DoctypeSubstate::SkipDeclaration))
-                        },
+                        "ENTITY" => self.into_state_continue(State::InsideDoctype(
+                            DoctypeSubstate::BeforeEntityName,
+                        )),
+                        "NOTATION" | "ELEMENT" | "ATTLIST" => self.into_state_continue(
+                            State::InsideDoctype(DoctypeSubstate::SkipDeclaration),
+                        ),
                         _ => Some(self.error(SyntaxError::UnknownMarkupDeclaration(buf.into()))),
                     }
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
             },
             DoctypeSubstate::BeforeEntityName => {
                 self.data.name.clear();
                 match t {
                     Token::Character(c) if is_whitespace_char(c) => None,
-                    Token::Character('%') => { // % is for PEDecl
+                    Token::Character('%') => {
+                        // % is for PEDecl
                         self.data.name.push('%');
-                        self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PEReferenceDefinitionStart))
-                    },
+                        self.into_state_continue(State::InsideDoctype(
+                            DoctypeSubstate::PEReferenceDefinitionStart,
+                        ))
+                    }
                     Token::Character(c) if is_name_start_char(c) => {
                         if self.data.name.len() > self.config.max_name_length {
                             return Some(self.error(SyntaxError::ExceededConfiguredLimit));
                         }
                         self.data.name.push(c);
                         self.into_state_continue(State::InsideDoctype(DoctypeSubstate::EntityName))
-                    },
+                    }
                     _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
                 }
-            },
+            }
             DoctypeSubstate::EntityName => match t {
-                Token::Character(c) if is_whitespace_char(c) => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::BeforeEntityValue))
-                },
+                Token::Character(c) if is_whitespace_char(c) => self
+                    .into_state_continue(State::InsideDoctype(DoctypeSubstate::BeforeEntityValue)),
                 Token::Character(c) if is_name_char(c) => {
                     if self.data.name.len() > self.config.max_name_length {
                         return Some(self.error(SyntaxError::ExceededConfiguredLimit));
                     }
                     self.data.name.push(c);
                     None
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::BeforeEntityValue => {
@@ -117,41 +273,54 @@ impl PullParser {
                         let name = self.data.take_name();
                         self.entities.entry(name).or_default(); // Dummy value, but at least the name is recognized
 
-                        self.into_state_continue(State::InsideDoctype(DoctypeSubstate::SkipDeclaration))
-                    },
+                        self.into_state_continue(State::InsideDoctype(
+                            DoctypeSubstate::SkipDeclaration,
+                        ))
+                    }
                     Token::SingleQuote | Token::DoubleQuote => {
                         self.data.quote = super::QuoteToken::from_token(t);
                         self.into_state_continue(State::InsideDoctype(DoctypeSubstate::EntityValue))
-                    },
+                    }
                     _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
                 }
-            },
+            }
             DoctypeSubstate::EntityValue => match t {
-                Token::SingleQuote if self.data.quote != Some(QuoteToken::SingleQuoteToken) => { self.buf.push('\''); None },
-                Token::DoubleQuote if self.data.quote != Some(QuoteToken::DoubleQuoteToken) => { self.buf.push('"'); None },
+                Token::SingleQuote if self.data.quote != Some(QuoteToken::SingleQuoteToken) => {
+                    self.buf.push('\'');
+                    None
+                }
+                Token::DoubleQuote if self.data.quote != Some(QuoteToken::DoubleQuoteToken) => {
+                    self.buf.push('"');
+                    None
+                }
                 Token::SingleQuote | Token::DoubleQuote => {
                     self.data.quote = None;
                     let name = self.data.take_name();
                     let val = self.take_buf();
                     self.entities.entry(name).or_insert(val); // First wins
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::SkipDeclaration)) // FIXME
-                },
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::SkipDeclaration))
+                    // FIXME
+                }
                 Token::ReferenceStart | Token::Character('&') => {
                     self.data.ref_data.clear();
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::NumericReferenceStart))
-                },
+                    self.into_state_continue(State::InsideDoctype(
+                        DoctypeSubstate::NumericReferenceStart,
+                    ))
+                }
                 Token::Character('%') => {
                     self.data.ref_data.clear();
                     self.data.ref_data.push('%'); // include literal % in the name to distinguish from regular entities
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PEReferenceInValue))
-                },
+                    self.into_state_continue(State::InsideDoctype(
+                        DoctypeSubstate::PEReferenceInValue,
+                    ))
+                }
                 Token::Character(c) if !self.is_valid_xml_char(c) => {
                     Some(self.error(SyntaxError::InvalidCharacterEntity(c as u32)))
-                },
+                }
                 Token::Character(c) => {
                     self.buf.push(c);
                     None
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::PEReferenceDefinitionStart => match t {
@@ -159,8 +328,10 @@ impl PullParser {
                 Token::Character(c) if is_name_start_char(c) => {
                     debug_assert_eq!(self.data.name, "%");
                     self.data.name.push(c);
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PEReferenceDefinition))
-                },
+                    self.into_state_continue(State::InsideDoctype(
+                        DoctypeSubstate::PEReferenceDefinition,
+                    ))
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::PEReferenceDefinition => match t {
@@ -170,17 +341,16 @@ impl PullParser {
                     }
                     self.data.name.push(c);
                     None
-                },
-                Token::Character(c) if is_whitespace_char(c) => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::BeforeEntityValue))
-                },
+                }
+                Token::Character(c) if is_whitespace_char(c) => self
+                    .into_state_continue(State::InsideDoctype(DoctypeSubstate::BeforeEntityValue)),
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::PEReferenceInDtd => match t {
                 Token::Character(c) if is_name_char(c) => {
                     self.data.ref_data.push(c);
                     None
-                },
+                }
                 Token::ReferenceEnd | Token::Character(';') => {
                     let name = self.data.take_ref_data();
                     match self.entities.get(&name) {
@@ -188,43 +358,46 @@ impl PullParser {
                             if let Err(e) = self.lexer.reparse(ent) {
                                 return Some(Err(e));
                             }
-                            self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
-                        },
+                            self.into_state_continue(State::InsideDoctype(
+                                DoctypeSubstate::InternalSubset,
+                            ))
+                        }
                         None => Some(self.error(SyntaxError::UndefinedEntity(name.into()))),
                     }
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::PEReferenceInValue => match t {
                 Token::Character(c) if is_name_char(c) => {
                     self.data.ref_data.push(c);
                     None
-                },
+                }
                 Token::ReferenceEnd | Token::Character(';') => {
                     let name = self.data.take_ref_data();
                     match self.entities.get(&name) {
                         Some(ent) => {
                             self.buf.push_str(ent);
-                            self.into_state_continue(State::InsideDoctype(DoctypeSubstate::EntityValue))
-                        },
+                            self.into_state_continue(State::InsideDoctype(
+                                DoctypeSubstate::EntityValue,
+                            ))
+                        }
                         None => Some(self.error(SyntaxError::UndefinedEntity(name.into()))),
                     }
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::NumericReferenceStart => match t {
-                Token::Character('#') => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::NumericReference))
-                },
+                Token::Character('#') => self
+                    .into_state_continue(State::InsideDoctype(DoctypeSubstate::NumericReference)),
                 Token::Character(c) if !self.is_valid_xml_char(c) => {
                     Some(self.error(SyntaxError::InvalidCharacterEntity(c as u32)))
-                },
+                }
                 Token::Character(c) => {
                     self.buf.push('&');
                     self.buf.push(c);
                     // named entities are not expanded inside doctype
                     self.into_state_continue(State::InsideDoctype(DoctypeSubstate::EntityValue))
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::NumericReference => match t {
@@ -234,24 +407,26 @@ impl PullParser {
                     match self.numeric_reference_from_str(&r) {
                         Ok(c) => {
                             self.buf.push(c);
-                            self.into_state_continue(State::InsideDoctype(DoctypeSubstate::EntityValue))
-                        },
+                            self.into_state_continue(State::InsideDoctype(
+                                DoctypeSubstate::EntityValue,
+                            ))
+                        }
                         Err(e) => Some(self.error(e)),
                     }
-                },
+                }
                 Token::Character(c) if !self.is_valid_xml_char(c) => {
                     Some(self.error(SyntaxError::InvalidCharacterEntity(c as u32)))
-                },
+                }
                 Token::Character(c) => {
                     self.data.ref_data.push(c);
                     None
-                },
+                }
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInEntity(t))),
             },
             DoctypeSubstate::SkipDeclaration => match t {
                 Token::TagEnd => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::Outside))
-                },
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset))
+                }
                 _ => None,
             },
         }

--- a/src/reader/parser/outside_tag.rs
+++ b/src/reader/parser/outside_tag.rs
@@ -139,7 +139,7 @@ impl PullParser {
                         self.data.doctype = Some(Token::DoctypeStart.to_string());
 
                         self.push_pos();
-                        self.into_state(State::InsideDoctype(DoctypeSubstate::Outside), next_event)
+                        self.into_state(State::InsideDoctype(DoctypeSubstate::BeforeDoctypeName), next_event)
                     },
 
                     Token::ProcessingInstructionStart => self.into_state(
@@ -196,7 +196,7 @@ impl PullParser {
                 self.data.doctype = Some(Token::DoctypeStart.to_string());
 
                 self.push_pos();
-                self.into_state(State::InsideDoctype(DoctypeSubstate::Outside), next_event)
+                self.into_state(State::InsideDoctype(DoctypeSubstate::BeforeDoctypeName), next_event)
             },
 
             Token::ProcessingInstructionStart => {

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -870,7 +870,7 @@ fn retrieve_doctype() {
 
     while let Ok(e) = parser.next() {
         match e {
-            XmlEvent::Doctype { syntax } => assert_eq!(syntax, expected),
+            XmlEvent::Doctype { syntax, .. } => assert_eq!(syntax, expected),
             XmlEvent::StartElement { .. } => break,
             _ => {},
         }
@@ -1035,7 +1035,7 @@ impl fmt::Display for Event<'_> {
                 XmlEvent::CData(ref data) => write!(f, r#"CData("{}")"#, data.escape_debug()),
                 XmlEvent::Characters(ref data) => write!(f, r#"Characters("{}")"#, data.escape_debug()),
                 XmlEvent::Whitespace(ref data) => write!(f, r#"Whitespace("{}")"#, data.escape_debug()),
-                XmlEvent::Doctype { ref syntax } => write!(f, r#"Doctype("{}")"#, syntax.escape_debug()),
+                XmlEvent::Doctype { ref syntax, .. } => write!(f, r#"Doctype("{}")"#, syntax.escape_debug()),
             },
             Err(ref e) => e.fmt(f),
         }

--- a/tests/xmltest.fail.txt
+++ b/tests/xmltest.fail.txt
@@ -1,6 +1,5 @@
 not-wf-sa-003 003.xml   Processing Instruction target name is required.
 not-wf-sa-054 054.xml   PUBLIC requires two literals.
-not-wf-sa-056 056.xml   Invalid Document Type Definition format - misplaced comment. 
 not-wf-sa-057 057.xml   This isn't SGML; comments can't exist in declarations. 
 not-wf-sa-058 058.xml   Invalid character , in ATTLIST enumeration 
 not-wf-sa-059 059.xml   String literal must be in quotes. 
@@ -22,7 +21,6 @@ not-wf-sa-081 081.xml   This tests the No External Entity References WFC,  since
 not-wf-sa-082 082.xml   This tests the No External Entity References WFC,  since the entity is referred to within an attribute. 
 not-wf-sa-083 083.xml   Undefined NOTATION n. 
 not-wf-sa-084 084.xml   Tests the Parsed Entity WFC by referring to an  unparsed entity. (This precedes the error of not declaring  that entity's notation, which may be detected any time before  the DTD parsing is completed.) 
-not-wf-sa-085 085.xml   Public IDs may not contain "[". 
 not-wf-sa-086 086.xml   Public IDs may not contain "[". 
 not-wf-sa-087 087.xml   Public IDs may not contain "[". 
 not-wf-sa-089 089.xml   Parameter entities "are" always parsed; NDATA annotations  are not permitted.
@@ -56,7 +54,6 @@ not-wf-sa-159 159.xml   Uses '&' unquoted in an entity declaration,  which is il
 not-wf-sa-160 160.xml   Violates the PEs in Internal Subset WFC  by using a PE reference within a declaration. 
 not-wf-sa-161 161.xml   Violates the PEs in Internal Subset WFC  by using a PE reference within a declaration. 
 not-wf-sa-162 162.xml   Violates the PEs in Internal Subset WFC  by using a PE reference within a declaration. 
-not-wf-sa-164 164.xml   Invalid placement of Parameter entity reference. 
 not-wf-sa-180 180.xml   The Entity Declared WFC requires entities to be declared  before they are used in an attribute list declaration. 
 not-wf-sa-181 181.xml   Internal parsed entities must match the content  production to be well formed. 
 not-wf-sa-182 182.xml   Internal parsed entities must match the content  production to be well formed. 


### PR DESCRIPTION
Improve Doctype parsing to distinguish internal subset state and process public and system id, processing them into fields passed to the Doctype event.

Introducing extra states for system and public parts of ExternalId.

Moving parts of what used to be process in Doctype substate "Outside" to substate "InternalSubset" where it fits better.

Passes three additional tests from xmltest.xml that deal with Doctype validity.

Fixes #55.