### PR TITLE
feat: add Clone implementation for EventReader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -155,6 +155,15 @@ impl<R: Read> IntoIterator for EventReader<R> {
     }
 }
 
+impl<R: Read + Clone> Clone for EventReader<R> {
+    fn clone(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+            parser: self.parser.clone()
+        }
+    }
+}
+
 /// An iterator over XML events created from some type implementing `Read`.
 ///
 /// When the next event is `xml::event::Error` or `xml::event::EndDocument`, then

--- a/src/reader/indexset.rs
+++ b/src/reader/indexset.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::hash::{BuildHasher, Hasher};
 
 /// An ordered set
+#[derive(Clone)]
 pub struct AttributesSet {
     vec: Vec<OwnedAttribute>,
     /// Uses a no-op hasher, because these u64s are hashes already
@@ -103,7 +104,7 @@ impl Hasher for U64Hasher {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct U64HasherBuilder;
 
 impl BuildHasher for U64HasherBuilder {

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -218,6 +218,7 @@ macro_rules! dispatch_on_enum_state(
 /// When it is not set, errors will be reported as `Err` objects with a string message.
 /// By default this flag is not set. Use `enable_errors` and `disable_errors` methods
 /// to toggle the behavior.
+#[derive(Clone)]
 pub(crate) struct Lexer {
     st: State,
     reader: CharReader,

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -61,6 +61,7 @@ type ElementStack = Vec<OwnedName>;
 pub type Result = super::Result<XmlEvent>;
 
 /// Pull-based XML parser.
+#[derive(Clone)]
 pub(crate) struct PullParser {
     config: ParserConfig,
     lexer: Lexer,
@@ -340,6 +341,7 @@ impl QuoteToken {
     }
 }
 
+#[derive(Clone)]
 struct MarkupData {
     name: String,     // used for processing instruction name
     ref_data: String,  // used for reference content

--- a/src/util.rs
+++ b/src/util.rs
@@ -97,6 +97,7 @@ impl fmt::Display for Encoding {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct CharReader {
     pub encoding: Encoding,
 }


### PR DESCRIPTION
As title, I added a `Clone` implementation for `EventReader` when the `source` is `Clone`.

My use-case: 

I have an in-memory stream of `&[u8]`, and I wish to start parsing (think a SOAP header). But the body is specific in so that I don't want to parse it right now. 

With this design I can have the header, and pass on the rest (think a SOAP body) to the handlers. Each handler can then decide whether they want to process it based on the header contents. 

Obviously this doesn't work when you use `BufReader` as that one isn't `Clone`. 


