### PR TITLE
Fix funding format for Liberapay entry

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: ["kornelski"]
-liberapay: ["kornel"]
+github: [kornelski]
+liberapay: kornel


### PR DESCRIPTION
Liberapay doesn't support array format

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository