### PR TITLE
Improve parsing performance by avoiding String reallocations

### DIFF
--- a/src/reader/indexset.rs
+++ b/src/reader/indexset.rs
@@ -22,7 +22,7 @@ const HASH_THRESHOLD: usize = 8;
 impl AttributesSet {
     pub fn new() -> Self {
         Self {
-            vec: Vec::new(),
+            vec: Vec::with_capacity(HASH_THRESHOLD),
             hasher: RandomState::new(),
             may_contain: HashSet::default(),
         }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -15,6 +15,8 @@ use crate::reader::lexer::{Lexer, Token};
 use std::collections::HashMap;
 use std::io::Read;
 
+static STRING_RESERVE_CAPACITY: usize = 20;
+
 macro_rules! gen_takes(
     ($($field:ident -> $method:ident, $t:ty, $def:expr);+) => (
         $(
@@ -31,8 +33,8 @@ macro_rules! gen_takes(
 );
 
 gen_takes!(
-    name         -> take_name, String, String::new();
-    ref_data     -> take_ref_data, String, String::new();
+    name         -> take_name, String, String::with_capacity(STRING_RESERVE_CAPACITY);
+    ref_data     -> take_ref_data, String, String::with_capacity(STRING_RESERVE_CAPACITY);
 
     encoding     -> take_encoding, Option<String>, None;
 
@@ -119,7 +121,7 @@ impl PullParser {
             lexer,
             st: State::DocumentStart,
             state_after_reference: State::OutsideTag,
-            buf: String::new(),
+            buf: String::with_capacity(STRING_RESERVE_CAPACITY),
             entities: HashMap::new(),
             nst: NamespaceStack::default(),
 
@@ -502,7 +504,7 @@ impl PullParser {
 
     #[inline]
     fn take_buf(&mut self) -> String {
-        std::mem::take(&mut self.buf)
+        std::mem::replace(&mut self.buf, String::with_capacity(STRING_RESERVE_CAPACITY))
     }
 
     #[inline]


### PR DESCRIPTION
We gain an about 10.7% performance improvement in the xml-rs integration in Chromium in blink_perf.parser xml parsing benchmark with this change. [1]

The problem in particular with the PullParser.buf is that after .take_buf() the buffer is reset to an empty String, and then single character or token pushes follow, leading to a lot of reallocations.

Instead, reset to an allocated buffer of size 20, which is choosen somewhat arbitraily as a compromise between covering many XML name length and avoiding too large temporary allocations.

Similarly, keep AttributeSet larger instead of needing reallocations to grow it. Accounts for about 1-2% of the perf improvement.

[1] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/perf_tests/parser/xml-parser.html?q=xml-parser.html