### PR TITLE
chore: gitignore the files that might be generated by tarpaulin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 *.iml
 /tests/xmlconf/
 .DS_Store
+
+cobertura.xml
+lcov.info
+tarpaulin-report.*


### PR DESCRIPTION
The test coverage reporting crate.

I ran tarpaulin on the code. It shows that the xml crates has 83.5% test coverage. Very nice.
