### PR TITLE
Avoid reallocations for reading qualified names

### DIFF
--- a/src/reader/parser/inside_opening_tag.rs
+++ b/src/reader/parser/inside_opening_tag.rs
@@ -36,10 +36,10 @@ impl PullParser {
                 Token::EmptyTagEnd => self.emit_start_element(true),
                 Token::Character(c) if is_whitespace_char(c) => None, // skip whitespace
                 Token::Character(c) if is_name_start_char(c) => {
-                    if self.buf.len() > self.config.max_name_length {
+                    if self.qualified_name_buf.len() > self.config.max_name_length {
                         return Some(self.error(SyntaxError::ExceededConfiguredLimit));
                     }
-                    self.buf.push(c);
+                    self.qualified_name_buf.push(c);
                     self.into_state_continue(State::InsideOpeningTag(OpeningTagSubstate::InsideAttributeName))
                 },
                 _ => Some(self.error(SyntaxError::UnexpectedTokenInOpeningTag(t))),


### PR DESCRIPTION
Qualified names accumulate into buf, but drop their scratch space after every completion of reading a qualified name. At the end of reading a qualified name, the scratch space only needs to be read by reference. The allocation of the value returned to the API client happens in OwnedName.

By using a separate scratch space `qualified_name_buf`, we can operate on the same scratch space string for each time reading a qualified name.