### PR TITLE
Improve well-formedness checks for Processing Instructions

### DIFF
--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -262,7 +262,7 @@ pub(crate) enum DoctypeSubstate {
     /// name definition
     PEReferenceDefinitionStart,
     PEReferenceDefinition,
-    IgnorePI,
+    PI(ProcessingInstructionSubstate),
     SkipDeclaration,
     Comment,
 }
@@ -288,8 +288,8 @@ pub(crate) enum ClosingTagSubstate {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub(crate) enum ProcessingInstructionSubstate {
-    PIInsideName,
-    PIInsideData,
+    PIReadingName,
+    PIReadingData,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/src/reader/parser/inside_doctype.rs
+++ b/src/reader/parser/inside_doctype.rs
@@ -5,7 +5,7 @@ use crate::reader::error::SyntaxError;
 use crate::reader::lexer::Token;
 use crate::reader::XmlEvent;
 
-use super::{DoctypeSubstate, PullParser, QuoteToken, Result, State};
+use super::{DoctypeSubstate, ProcessingInstructionSubstate, PullParser, QuoteToken, Result, State};
 
 impl PullParser {
     pub fn inside_doctype(&mut self, t: Token, substate: DoctypeSubstate) -> Option<Result> {
@@ -180,16 +180,12 @@ impl PullParser {
                 }
                 Token::Character(c) if is_whitespace_char(c) => None,
                 Token::ProcessingInstructionStart => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::IgnorePI))
+                    self.buf.clear();
+                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PI(ProcessingInstructionSubstate::PIReadingName)))
                 }
                 _ => Some(self.error(SyntaxError::UnexpectedToken(t))),
             },
-            DoctypeSubstate::IgnorePI => match t {
-                Token::ProcessingInstructionEnd => {
-                    self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset))
-                }
-                _ => None,
-            },
+            DoctypeSubstate::PI(s) => self.inside_processing_instruction(t, s),
             DoctypeSubstate::String => match t {
                 Token::SingleQuote if self.data.quote != Some(QuoteToken::SingleQuoteToken) => None,
                 Token::DoubleQuote if self.data.quote != Some(QuoteToken::DoubleQuoteToken) => None,

--- a/src/reader/parser/inside_processing_instruction.rs
+++ b/src/reader/parser/inside_processing_instruction.rs
@@ -4,12 +4,12 @@ use crate::reader::error::SyntaxError;
 use crate::reader::events::XmlEvent;
 use crate::reader::lexer::Token;
 
-use super::{DeclarationSubstate, Encountered, ProcessingInstructionSubstate, PullParser, Result, State};
+use super::{DeclarationSubstate, DoctypeSubstate, Encountered, ProcessingInstructionSubstate, PullParser, Result, State};
 
 impl PullParser {
     pub fn inside_processing_instruction(&mut self, t: Token, s: ProcessingInstructionSubstate) -> Option<Result> {
         match s {
-            ProcessingInstructionSubstate::PIInsideName => match t {
+            ProcessingInstructionSubstate::PIReadingName => match t {
                 Token::Character(c) if self.buf.is_empty() && is_name_start_char(c) ||
                                  self.buf_has_data() && is_name_char(c) => {
                     if self.buf.len() > self.config.max_name_length {
@@ -37,6 +37,11 @@ impl PullParser {
 
                         // All is ok, emitting event
                         _ => {
+                            if matches!(self.st, State::InsideDoctype(_)) {
+                                // PIs are allowed inside DOCTYPE internal subset, but we currently ignore them
+                                return self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset));
+                            }
+
                             debug_assert!(self.next_event.is_none(), "{:?}", self.next_event);
                             // can't have a PI before `<?xml`
                             let event1 = self.set_encountered(Encountered::Declaration);
@@ -58,6 +63,9 @@ impl PullParser {
                     let name = self.take_buf();
 
                     match &*name {
+                        // Name is empty, it is an error
+                        "" => Some(self.error(SyntaxError::ProcessingInstructionWithoutName)),
+
                         // We have not ever encountered an element and have not parsed XML declaration
                         "xml" if self.encountered == Encountered::None => {
                             self.into_state_continue(State::InsideDeclaration(DeclarationSubstate::BeforeVersion))
@@ -72,9 +80,13 @@ impl PullParser {
                         // All is ok, starting parsing PI data
                         _ => {
                             self.data.name = name;
+                            if matches!(self.st, State::InsideDoctype(_)) {
+                                // PIs are allowed inside DOCTYPE internal subset, but we currently ignore them
+                                return self.into_state_continue(State::InsideDoctype(DoctypeSubstate::PI(ProcessingInstructionSubstate::PIReadingData)));
+                            }
                             // can't have a PI before `<?xml`
                             let next_event = self.set_encountered(Encountered::Declaration);
-                            self.into_state(State::InsideProcessingInstruction(ProcessingInstructionSubstate::PIInsideData), next_event)
+                            self.into_state(State::InsideProcessingInstruction(ProcessingInstructionSubstate::PIReadingData), next_event)
                         },
                     }
                 },
@@ -85,10 +97,14 @@ impl PullParser {
                 },
             },
 
-            ProcessingInstructionSubstate::PIInsideData => match t {
+            ProcessingInstructionSubstate::PIReadingData => match t {
                 Token::ProcessingInstructionEnd => {
                     let name = self.data.take_name();
                     let data = self.take_buf();
+                    if matches!(self.st, State::InsideDoctype(_)) {
+                        // PIs are allowed inside DOCTYPE internal subset, but we currently ignore them
+                        return self.into_state_continue(State::InsideDoctype(DoctypeSubstate::InternalSubset));
+                    }
                     self.into_state_emit(
                         State::OutsideTag,
                         Ok(XmlEvent::ProcessingInstruction { name, data: Some(data) }),

--- a/src/reader/parser/outside_tag.rs
+++ b/src/reader/parser/outside_tag.rs
@@ -143,7 +143,7 @@ impl PullParser {
                     },
 
                     Token::ProcessingInstructionStart => self.into_state(
-                        State::InsideProcessingInstruction(ProcessingInstructionSubstate::PIInsideName),
+                        State::InsideProcessingInstruction(ProcessingInstructionSubstate::PIReadingName),
                         next_event,
                     ),
 
@@ -202,7 +202,7 @@ impl PullParser {
             Token::ProcessingInstructionStart => {
                 self.push_pos();
                 self.into_state_continue(State::InsideProcessingInstruction(
-                    ProcessingInstructionSubstate::PIInsideName,
+                    ProcessingInstructionSubstate::PIReadingName,
                 ))
             },
 

--- a/tests/sun-not-wf.fail.txt
+++ b/tests/sun-not-wf.fail.txt
@@ -19,7 +19,6 @@ dtd04 dtd04.xml   PUBLIC literal must be quoted
 dtd05 dtd05.xml   SYSTEM identifier must be quoted
 dtd07 dtd07.xml   Text declarations (which optionally begin any external entity)  are required to have "encoding=...". 
 encoding07 encoding07.xml   Text declarations (which optionally begin any external entity)  are required to have "encoding=...". 
-pi pi.xml   No space between PI target name and data
 pubid01 pubid01.xml   Illegal entity ref in public ID
 pubid02 pubid02.xml   Illegal characters in public ID
 pubid03 pubid03.xml   Illegal characters in public ID

--- a/tests/xmltest.fail.txt
+++ b/tests/xmltest.fail.txt
@@ -1,4 +1,3 @@
-not-wf-sa-003 003.xml   Processing Instruction target name is required.
 not-wf-sa-054 054.xml   PUBLIC requires two literals.
 not-wf-sa-057 057.xml   This isn't SGML; comments can't exist in declarations. 
 not-wf-sa-058 058.xml   Invalid character , in ATTLIST enumeration 
@@ -48,7 +47,6 @@ not-wf-sa-136 136.xml   Tag omission is invalid in XML.
 not-wf-sa-137 137.xml   Space is required before a content model. 
 not-wf-sa-138 138.xml   Invalid syntax for content particle. 
 not-wf-sa-139 139.xml   The element-content model should not be empty. 
-not-wf-sa-149 149.xml   XML Declaration may not be within a DTD.
 not-wf-sa-158 158.xml   SGML-ism: "#NOTATION gif" can't have attributes. 
 not-wf-sa-159 159.xml   Uses '&' unquoted in an entity declaration,  which is illegal syntax for an entity reference.
 not-wf-sa-160 160.xml   Violates the PEs in Internal Subset WFC  by using a PE reference within a declaration. 
@@ -60,7 +58,6 @@ not-wf-sa-182 182.xml   Internal parsed entities must match the content  product
 not-wf-sa-183 183.xml   Mixed content declarations may not include content particles.
 not-wf-sa-184 184.xml   In mixed content models, element names must not be  parenthesized. 
 not-wf-not-sa-001 001.xml   Conditional sections must be properly terminated ("]>" used  instead of "]]>"). 
-not-wf-not-sa-002 002.xml   Processing instruction target names may not be "XML"  in any combination of cases. 
 not-wf-not-sa-003 003.xml   Conditional sections must be properly terminated ("]]>" omitted). 
 not-wf-not-sa-004 004.xml   Conditional sections must be properly terminated ("]]>" omitted). 
 not-wf-not-sa-005 005.xml   Tests the Entity Declared VC by referring to an  undefined parameter entity within an external entity.


### PR DESCRIPTION
Cover cases where a PI occurs inside doctype, instead of ignoring. This allows the parser to detect wellformedness issues, for example discovering an invalid <?xml inside a doctype, not at the beginning of the file.

We still ignore PIs in DOCTYPE and do not send them upwards, but we better detect non-wellformed documents now.

Passes 4 new tests.