### PR TITLE
Return Unexpected EOF for broken CDATA under ignoring EOF config

### DIFF
--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -235,6 +235,7 @@ pub(crate) struct Lexer {
 
     max_entity_expansion_depth: u8,
     max_entity_expansion_length: usize,
+    pub(crate) ignore_end_of_stream: bool,
 }
 
 impl Position for Lexer {
@@ -261,6 +262,7 @@ impl Lexer {
 
             max_entity_expansion_depth: config.max_entity_expansion_depth,
             max_entity_expansion_length: config.max_entity_expansion_length,
+            ignore_end_of_stream: config.ignore_end_of_stream,
         }
     }
 
@@ -333,7 +335,9 @@ impl Lexer {
         self.eof_handled = true;
         self.pos = self.head_pos;
         match self.st {
-            State::InsideCdata | State::CDataClosing(_) => Err(self.error(SyntaxError::UnclosedCdata)),
+            State::InsideCdata | State::CDataClosing(_) if !self.ignore_end_of_stream =>
+                Err(self.error(SyntaxError::UnclosedCdata)),
+            State::InsideCdata | State::CDataClosing(_) |
             State::TagStarted | State::CommentOrCDataOrDoctypeStarted |
             State::CommentStarted | State::CDataStarted(_)| State::DoctypeStarted(_) |
             State::CommentClosing(_) |

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -424,3 +424,24 @@ fn test_all_splits_invalid_cdata_err() {
         assert!(error_found, "Did not find expected 'Unexpected token: ]]> error for split at {i}");
     }
 }
+
+#[test]
+fn test_cdata_split_error_type() {
+    let xml_cdata = "<root><![CDATA[ partial";
+    let mut reader_cdata = ParserConfig::new()
+        .ignore_end_of_stream(true)
+        .create_reader(BufReader::new(Cursor::new(xml_cdata.as_bytes())));
+
+    reader_cdata.next().unwrap(); // StartDocument
+    reader_cdata.next().unwrap(); // StartElement(root)
+    let err_cdata = reader_cdata.next().unwrap_err();
+    assert!(err_cdata.to_string().contains("Unexpected end of stream"), "Error was: {}", err_cdata);
+
+    let xml_cdata_no_resumable = "<root><![CDATA[ partial";
+    let mut reader_cdata_no_resumable = EventReader::new(xml_cdata_no_resumable.as_bytes());
+    reader_cdata_no_resumable.next().unwrap(); // StartDocument
+    reader_cdata_no_resumable.next().unwrap(); // StartElement(root)
+    let err_cdata_no_resumable = reader_cdata_no_resumable.next().unwrap_err();
+    assert!(err_cdata_no_resumable.to_string().contains("Unclosed <![CDATA["), "Error was: {}", err_cdata_no_resumable);
+}
+


### PR DESCRIPTION
When the parser is configured to ignore EOF in order to enable chunked and resumable parsing, most interrupted parsing states result in an unexpected EOF error, however, for CDATA we were still returning "Unclosed <!CDATA" errors.

Ensure that for CDATA the error is also unepxected EOF - so that clients can identify the error type and attempt to resume.

Chromium/Blink were checking for that and still did not correctly resume for CDATA, which is fixed with this change.